### PR TITLE
Fix error when installing starship with `bash`

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,7 +1,7 @@
 FROM jpconsuegra/autogoal
 
 RUN curl -fsSL https://starship.rs/install.sh > ~/starship.sh
-RUN bash ~/starship.sh --yes
+RUN sh ~/starship.sh --yes
 RUN echo 'eval "$(starship init bash)"' >> ~/.bashrc
 RUN rm ~/starship.sh
 


### PR DESCRIPTION
It seems that something changed in the starship install script. It now errors if it is run with _non-posix_ `bash`. Changing to `sh` fixes this.